### PR TITLE
fix: Use system Python packages instead of pip installations

### DIFF
--- a/src/ctf_evals_core/images/agent-environment/Dockerfile
+++ b/src/ctf_evals_core/images/agent-environment/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get update \
     python-is-python3 \
     python3 \
     python3-pip \
+    python3-opencv \
+    python3-pil \
     python3-venv \
     qemu-user \
     sleuthkit \
@@ -33,10 +35,8 @@ RUN apt-get update \
     wireshark \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --no-cache-dir \
-    opencv-python \
-    pillow \
-    stegoveritas
+# Note: stegoveritas isn't available as a system package, so we'll need to use pip for just that one
+RUN pip3 install --no-cache-dir --break-system-packages stegoveritas
 
 WORKDIR /root/
 


### PR DESCRIPTION
## Description
Fixes PEP 668 error during Docker image builds by using system Python packages instead of pip installations where possible. 

## The issue

Error Details: The build fails when executing:

```bash
RUN pip3 install --no-cache-dir \
    opencv-python \
    pillow \
    stegoveritas
```

With the error:

```bash
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
```

## Changes
- Replace pip installations with equivalent system packages:
  - `opencv-python` → `python3-opencv`
  - `pillow` → `python3-pil`
- Use `--break-system-packages` flag only for stegoveritas (no system package available)