### PR TITLE
Add `get_from_metadata`

### DIFF
--- a/src/ctf_evals_core/__init__.py
+++ b/src/ctf_evals_core/__init__.py
@@ -1,3 +1,4 @@
+from ._util.utils import get_from_metadata
 from .dataset import create_dataset, filter_dataset_by_variant
 from .model import ChallengeInfo, Variant
 from .task import ctf_task
@@ -8,4 +9,5 @@ __all__ = [
     "Variant",
     "create_dataset",
     "filter_dataset_by_variant",
+    "get_from_metadata",
 ]

--- a/src/ctf_evals_core/_util/utils.py
+++ b/src/ctf_evals_core/_util/utils.py
@@ -1,7 +1,9 @@
 from typing import Any
 
 
-def get_from_metadata[T](metadata: dict[str, Any], key: str, default: T = None) -> T:
+def get_from_metadata[T](
+    metadata: dict[str, Any] | None, key: str, default: T | None = None
+) -> T | None:
     """
     Get a value from metadata, with a default value if it doesn't exist.
 

--- a/src/ctf_evals_core/_util/utils.py
+++ b/src/ctf_evals_core/_util/utils.py
@@ -7,7 +7,7 @@ def get_from_metadata[T](
     """
     Get a value from metadata, with a default value if it doesn't exist.
 
-    For a ctf task it will first look in the sample_metadata, then the
+    For a ctf task it will first look in the variant_metadata, then the
     challenge_metadata, then the metadata.
 
     Args:
@@ -15,9 +15,9 @@ def get_from_metadata[T](
         key: The key to get.
         default: The default value to return if the key doesn't exist.
     """
-    if metadata is None:
-        result: T | None = default
-    elif "variant_metadata" in metadata and key in metadata["variant_metadata"]:
+    assert metadata is not None, "Inspect metadata should never be None"
+
+    if "variant_metadata" in metadata and key in metadata["variant_metadata"]:
         result = metadata["variant_metadata"][key]
     elif "challenge_metadata" in metadata and key in metadata["challenge_metadata"]:
         result = metadata["challenge_metadata"][key]

--- a/src/ctf_evals_core/_util/utils.py
+++ b/src/ctf_evals_core/_util/utils.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+
+def get_from_metadata[T](metadata: dict[str, Any], key: str, default: T = None) -> T:
+    """
+    Get a value from metadata, with a default value if it doesn't exist.
+
+    For a ctf task it will first look in the sample_metadata, then the
+    challenge_metadata, then the metadata.
+
+    Args:
+        metadata: The metadata dictionary.
+        key: The key to get.
+        default: The default value to return if the key doesn't exist.
+    """
+    if metadata is None:
+        result: T | None = default
+    elif "variant_metadata" in metadata and key in metadata["variant_metadata"]:
+        result = metadata["variant_metadata"][key]
+    elif "challenge_metadata" in metadata and key in metadata["challenge_metadata"]:
+        result = metadata["challenge_metadata"][key]
+    elif key in metadata:
+        result = metadata[key]
+    else:
+        result = default
+    return result

--- a/src/ctf_evals_core/dataset.py
+++ b/src/ctf_evals_core/dataset.py
@@ -5,10 +5,10 @@ from pathlib import Path
 from typing import Any, Callable
 
 import yaml
-from ._util.utils import get_from_metadata
 from inspect_ai.dataset import MemoryDataset, Sample
 from inspect_ai.util import SandboxEnvironmentType
 
+from ._util.utils import get_from_metadata
 from .model import ChallengeInfo
 
 CHALLENGE_INFO_FILENAME = "challenge.yaml"
@@ -85,6 +85,7 @@ def filter_dataset_by_metadata(
         filters (dict[str, Any]): A dictionary of metadata filters to apply to the
             dataset. Only samples with metadata matching the filters are included.
     """
+
     def predicate(sample: Sample) -> bool:
         # All filters must be satisfied
         return all(

--- a/src/ctf_evals_core/dataset.py
+++ b/src/ctf_evals_core/dataset.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 import yaml
+from ._util.utils import get_from_metadata
 from inspect_ai.dataset import MemoryDataset, Sample
 from inspect_ai.util import SandboxEnvironmentType
 
@@ -84,21 +85,10 @@ def filter_dataset_by_metadata(
         filters (dict[str, Any]): A dictionary of metadata filters to apply to the
             dataset. Only samples with metadata matching the filters are included.
     """
-
-    def get_key_from_metadata(metadata, key) -> Any:
-        variant_metadata = metadata.get("variant_metadata", {})
-        challenge_metadata = metadata.get("challenge_metadata", {})
-        # Prefer variant metadata over challenge metadata over typical metadata
-        # using defaults
-        value = variant_metadata.get(
-            key, challenge_metadata.get(key, metadata.get(key, None))
-        )
-        return value
-
     def predicate(sample: Sample) -> bool:
         # All filters must be satisfied
         return all(
-            get_key_from_metadata(sample.metadata, key) == value
+            get_from_metadata(metadata=sample.metadata, key=key) == value
             for key, value in filters.items()
         )
 


### PR DESCRIPTION
When we build inspect task metadata from challenge.yaml we put it in this structure:
```
metadata:
    data: set
    by: inspect
    challenge_metadata:
       anything_found_in: challenge.yaml#metadata
    variant_metadata:
      anything_found_in: challeng.yaml#variants.this_variant.metadata
```

This PR adds a `get_from_metadata` function with the logic: 
- look for key in sample_metadata 
- else look in challenge_metadata
- else look in metadata
- else return default

I end up rewriting this function a lot so seems useful to just expose it in this package