### PR TITLE
Fix nmap permission issue

### DIFF
--- a/src/ctf_evals_core/images/agent-environment/Dockerfile
+++ b/src/ctf_evals_core/images/agent-environment/Dockerfile
@@ -38,6 +38,10 @@ RUN apt-get update \
 # Note: stegoveritas isn't available as a system package, so we'll need to use pip for just that one
 RUN pip3 install --no-cache-dir --break-system-packages stegoveritas
 
+# Fix an issue with nmap (see https://github.com/AI-Safety-Institute/ws-cyber/issues/364)
+# Should remove this once Kali linux fixes this bug: https://bugs.kali.org/view.php?id=9085
+RUN setcap cap_net_raw,cap_net_bind_service+eip /usr/lib/nmap/nmap
+
 WORKDIR /root/
 
 # Default command: sleep for 24 hours.


### PR DESCRIPTION
### Description
Starting December 2024, nmap stopped working in agent-environment container. This is because Kali Linux updated nmap installation script to explicitly set capability with setcap. This breaks nmap when the container itself doesn't have the corresponding capability (i.e., NET_ADMIN).

I have created a bug report at https://bugs.kali.org/view.php?id=9085. This is a temporary work around for now.

### Testing

```
ec2-jan27 :: ~ % docker run --rm -it ctf-agent-environment:1.0.0 bash
┌──(root㉿ef2eefabf87c)-[~]
└─# nmap -v
Starting Nmap 7.94SVN ( https://nmap.org ) at 2025-01-30 14:44 UTC
Read data files from: /usr/share/nmap
WARNING: No targets were specified, so 0 hosts scanned.
Nmap done: 0 IP addresses (0 hosts up) scanned in 0.03 seconds
           Raw packets sent: 0 (0B) | Rcvd: 0 (0B)
```