### PR TITLE
Bumped kali docker version due to the signing key incident.

### DIFF
--- a/src/ctf_evals_core/images/agent-environment/Dockerfile
+++ b/src/ctf_evals_core/images/agent-environment/Dockerfile
@@ -2,7 +2,7 @@
 # Use the command below to target a new release
 # docker pull kalilinux/kali-last-release
 # docker inspect -f '{{json .RepoDigests}}' kalilinux/kali-last-release | jq -r '.[0]'
-FROM kalilinux/kali-last-release@sha256:92935ba0b1053dc765e627edb65d1981341b662ccaea99271f5ab40e387483a1
+FROM kalilinux/kali-last-release@sha256:99d99f1c1349a5e1fa8f862875ad204ffc009599e2a6c4ed617d16f6d5bae241
 
 # Avoid prompts during package installation.
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
If you haven't seen: https://www.kali.org/blog/new-kali-archive-signing-key/

This caused issues when building the agent image:

```bash
ubuntu@pwnbox:~/kal$ ctf_eval images build
Building 1 images...
[+] Building 5.7s (3/8)                                                                                                                                              docker:default
...
 => => sha256:84d02b54311f02240400fcedfbf395408cd2ceb5567ecbbc1e869da07596e12f 55.38MB / 55.38MB                                                                       2.4s  => => extracting sha256:84d02b54311f02240400fcedfbf395408cd2ceb5567ecbbc1e869da07596e12f                                                                              2.0s
 => ERROR [2/5] RUN apt-get update     && apt-get install -y     kali-linux-headless     fdisk     foremost     gcc-aarch64-linux-gnu     gdb     gobuster     iputil  0.9s
------
 > [2/5] RUN apt-get update     && apt-get install -y     kali-linux-headless     fdisk     foremost     gcc-aarch64-linux-gnu     gdb     gobuster     iputils-ping     libc6-dev-arm64-cross     netbase     openssh-client     outguess     python-is-python3     python3     python3-pip     python3-opencv     python3-pil     python3-venv     qemu-user     sleuthkit     sshpass     steghide     tcpflow     unzip     wireshark     && rm -rf /var/lib/apt/lists/*:
0.463 Get:1 http://kali.download/kali kali-last-snapshot InRelease [41.5 kB]
0.635 Err:1 http://kali.download/kali kali-last-snapshot InRelease
0.635   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY ED65462EC8D5E4C5
0.637 Reading package lists...
0.646 W: GPG error: http://kali.download/kali kali-last-snapshot InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY ED65462EC8D5E4C5
0.646 E: The repository 'http://http.kali.org/kali kali-last-snapshot InRelease' is not signed.
------
Dockerfile:10
--------------------
   9 |
  10 | >>> RUN apt-get update \
  11 | >>>     && apt-get install -y \
  12 | >>>     kali-linux-headless \
  13 | >>>     fdisk \
  14 | >>>     foremost \
  15 | >>>     gcc-aarch64-linux-gnu \
  16 | >>>     gdb \
  17 | >>>     gobuster \
  18 | >>>     iputils-ping \
  19 | >>>     libc6-dev-arm64-cross \
  20 | >>>     netbase \
  21 | >>>     openssh-client \
  22 | >>>     outguess \
  23 | >>>     python-is-python3 \
  24 | >>>     python3 \
  25 | >>>     python3-pip \
  26 | >>>     python3-opencv \
  27 | >>>     python3-pil \
  28 | >>>     python3-venv \
  29 | >>>     qemu-user \
  30 | >>>     sleuthkit \
  31 | >>>     sshpass \
  32 | >>>     steghide \
  33 | >>>     tcpflow \
  34 | >>>     unzip \
  35 | >>>     wireshark \
  36 | >>>     && rm -rf /var/lib/apt/lists/*
  37 |
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update     && apt-get install -y     kali-linux-headless     fdisk     foremost     gcc-aarch64-linux-gnu     gdb     gobuster     iputils-ping     libc6-dev-arm64-cross     netbase     openssh-client     outguess     python-is-python3     python3     python3-pip     python3-opencv     python3-pil     python3-venv     qemu-user     sleuthkit     sshpass     steghide     tcpflow     unzip     wireshark     && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
Failed to build image ctf-agent-environment:1.0.0
```

Bumped to the current latest release. 